### PR TITLE
description field for request mapping in solidity

### DIFF
--- a/contracts/SocialIdentityLinker.sol
+++ b/contracts/SocialIdentityLinker.sol
@@ -11,6 +11,7 @@ contract SocialIdentityLinker is usingOraclize {
     struct _struct {
         address _address;
         uint256 _amount;
+        string _description;
     }
 
     mapping (uint256 => address) public facebookIdentity;
@@ -62,12 +63,14 @@ contract SocialIdentityLinker is usingOraclize {
     }
 
     function requestEth(address _requestee,
-                        uint _amount) public
+                        uint _amount,
+                        string _description) public
     {
 
         _struct s;
         s._address = _requestee;
         s._amount = _amount;
+        s._description = _description;
 
         requestEthStruct[msg.sender].push(s);
 


### PR DESCRIPTION

Tested:

truffle(develop)> app.requestEth(web3.eth.accounts[1], web3.toWei(3,"ether"),"**jits lesson**" )
{ tx: '0x71fafd1669fb16b2b9abc210cfcfb545d049c678af01be5f69d366da1fec8dab',
  receipt:
   { transactionHash: '0x71fafd1669fb16b2b9abc210cfcfb545d049c678af01be5f69d366da1fec8dab',
     transactionIndex: 0,
     blockHash: '0xf589d8db3e8b0898853cd46b79af5d6a3a484349b3cd041991a602d85618afbf',
     blockNumber: 9,
     gasUsed: 296853,
     cumulativeGasUsed: 296853,
     contractAddress: null,
     logs: [] },
  logs: [] }


truffle(develop)> app.requestEthStruct(web3.eth.accounts[0],0)
[ '0xf17f52151ebef6c7334fad080c5704d77216b732',
  BigNumber { s: 1, e: 18, c: [ 30000 ] },
  '**jits lesson**' ]